### PR TITLE
feat(#833): Add chat amounts to menu link

### DIFF
--- a/src/menuV2/package.json
+++ b/src/menuV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buerokratt-ria/menu",
-  "version": "0.1.16",
+  "version": "0.2.0",
   "description": "Generic MainNavigation component that would be injected as dependency.",
   "main": "index.js",
   "scripts": {},

--- a/src/menuV2/src/menu/components/menuTree/index.tsx
+++ b/src/menuV2/src/menu/components/menuTree/index.tsx
@@ -15,9 +15,22 @@ interface MenuTreeProps {
   handleNavToggle: (event: MouseEvent) => void;
 }
 
+interface MenuItemLabelProps {
+  menuItem: MenuItem
+  currentlySelectedLanguage: string
+}
+
+const MenuItemLabel: React.FC<MenuItemLabelProps> = ({ menuItem, currentlySelectedLanguage }) => {
+  return (
+    <>
+      {menuItem.label[currentlySelectedLanguage]} {menuItem.count != null ? `(${menuItem.count})` : ''}
+    </>
+  );
+};
+
 const MenuTree: FC<MenuTreeProps> = ({
-  menuItems, 
-  serviceId, 
+  menuItems,
+  serviceId,
   handleNavToggle,
 }) => {
   const currentlySelectedLanguage = useTranslation().i18n.language;
@@ -50,10 +63,10 @@ const MenuTree: FC<MenuTreeProps> = ({
         ) : (
           serviceId.includes(menuItem.id!)
             ? <NavLink to={menuItem.path || '#'}>
-                {menuItem.label[currentlySelectedLanguage]}
+                <MenuItemLabel menuItem={menuItem} currentlySelectedLanguage={currentlySelectedLanguage} />
               </NavLink>
             : <a href={(menuData.find(dataItem => dataItem.id === menuItem.id)?.url ?? '') + menuItem.path}>
-                {menuItem.label[currentlySelectedLanguage]}
+                <MenuItemLabel menuItem={menuItem} currentlySelectedLanguage={currentlySelectedLanguage} />
               </a>
         )}
       </li>

--- a/src/menuV2/src/menu/hooks/useFilteredMenuItems.tsx
+++ b/src/menuV2/src/menu/hooks/useFilteredMenuItems.tsx
@@ -1,31 +1,37 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { MenuItem } from "../types/menuItem";
 import useMenuItems from "./useMenuItems";
+import { CountConf } from "../types/countConf";
 
-const useFilteredMenuItems = () => {
-  const items = useMenuItems();
+const useFilteredMenuItems = (countConf?: CountConf) => {
+  const items = useMenuItems(countConf);
   const [menuItems, setMenuItems] = useState<MenuItem[]>([]);
 
-  useQuery({
+  const { data } = useQuery<{ response: [] }>({
     queryKey: ['accounts/user-role', 'prod'],
-    onSuccess: (res: any) => {
-      const filteredItems = items.filter((item) => {
-        const role = res.response;
-        if (role.includes('ROLE_ADMINISTRATOR'))
-          return item.id;
-        if (role.includes('ROLE_SERVICE_MANAGER'))
-          return item.id != "settings" && item.id != "training";
-        if (role.includes('ROLE_CUSTOMER_SUPPORT_AGENT'))
-          return item.id != "settings" && item.id != "analytics";
-        if (role.includes('ROLE_CHATBOT_TRAINER'))
-          return item.id != "settings" && item.id != "conversations";
-        if (role.includes('ROLE_ANALYST'))
-          return item.id == "analytics" || item.id == "monitoring"; 
-      });
-      setMenuItems(filteredItems ?? []);
-    },
   });
+
+  useEffect(() => {
+    const filteredItems = items.filter((item) => {
+      if (!data) {
+        return;
+      }
+      const role: any[] = data.response;
+      if (role.includes('ROLE_ADMINISTRATOR'))
+        return item.id;
+      if (role.includes('ROLE_SERVICE_MANAGER'))
+        return item.id != "settings" && item.id != "training";
+      if (role.includes('ROLE_CUSTOMER_SUPPORT_AGENT'))
+        return item.id != "settings" && item.id != "analytics";
+      if (role.includes('ROLE_CHATBOT_TRAINER'))
+        return item.id != "settings" && item.id != "conversations";
+      if (role.includes('ROLE_ANALYST'))
+        return item.id == "analytics" || item.id == "monitoring";
+    });
+
+    setMenuItems(filteredItems ?? []);
+  }, [items, data]);
 
   return menuItems;
 }

--- a/src/menuV2/src/menu/index.tsx
+++ b/src/menuV2/src/menu/index.tsx
@@ -6,10 +6,15 @@ import { useTranslation } from "react-i18next";
 import MenuTree from './components/menuTree';
 import useFilteredMenuItems from './hooks/useFilteredMenuItems';
 import './main-navigation.scss';
+import { CountConf } from "./types/countConf";
 
-const MainNavigation: FC = () => {
+interface MainNavigationProps {
+  countConf?: CountConf
+}
+
+const MainNavigation: FC<MainNavigationProps> = ({countConf}) => {
   const { t } = useTranslation();
-  const menuItems = useFilteredMenuItems();
+  const menuItems = useFilteredMenuItems(countConf);
   const serviceId = useMemo(() => import.meta.env.REACT_APP_SERVICE_ID.split(','), []);
 
   const [navCollapsed, setNavCollapsed] = useState(false);

--- a/src/menuV2/src/menu/types/countConf.ts
+++ b/src/menuV2/src/menu/types/countConf.ts
@@ -1,0 +1,3 @@
+export interface CountConf {
+   [key: string]: number
+}

--- a/src/menuV2/src/menu/types/menuItem.ts
+++ b/src/menuV2/src/menu/types/menuItem.ts
@@ -10,4 +10,5 @@ export interface MenuItem {
   target?: '_blank' | '_self';
   children?: MenuItem[];
   hidden?: boolean;
+  count?: number
 }


### PR DESCRIPTION
- Add conf option to MainNavigation component.
- Supports defining related paths and the count to display. Eg: MenuItem has /active element, countConf provides "/active": 5. This results in MenuItem label followed by count