### PR TITLE
feature(#833): Move menu counts hook to header

### DIFF
--- a/src/headerV2/index.ts
+++ b/src/headerV2/index.ts
@@ -9,3 +9,5 @@ export {
 export {
     default as Header
 } from './src';
+
+export { useMenuCountConf } from './src/hooks/useMenuCountConf'

--- a/src/headerV2/package.json
+++ b/src/headerV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buerokratt-ria/header",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Generic Header component that would be injected as dependency.",
   "main": "index.ts",
   "scripts": {},

--- a/src/headerV2/src/hooks/useMenuCountConf.tsx
+++ b/src/headerV2/src/hooks/useMenuCountConf.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import useStore from "../store/store";
+
+export const useMenuCountConf = () => {
+  const unansweredChatsLength = useStore((state) => state.unansweredChatsLength());
+  const { myChats, otherChats } = useStore((state) => state.getGroupedActiveChats());
+  const pendingChatsLength = useStore((state) => state.pendingChats.length);
+
+  const [menuCountConf, setMenuCountConf] = useState({});
+
+  useEffect(() => {
+    setMenuCountConf({
+      '/unanswered': unansweredChatsLength,
+      '/active': otherChats.length + myChats.length,
+      '/pending': pendingChatsLength,
+    });
+  }, [unansweredChatsLength, otherChats.length, myChats.length, pendingChatsLength]);
+
+  return menuCountConf;
+};

--- a/src/headerV2/src/hooks/useMenuCountConf.tsx
+++ b/src/headerV2/src/hooks/useMenuCountConf.tsx
@@ -4,7 +4,7 @@ import useStore from "../store/store";
 export const useMenuCountConf = () => {
   const unansweredChatsLength = useStore((state) => state.unansweredChatsLength());
   const { myChats, otherChats } = useStore((state) => state.getGroupedActiveChats());
-  const pendingChatsLength = useStore((state) => state.pendingChats.length);
+  const pendingChatsLength = useStore((state) => state.pendingChatsLength());
 
   const [menuCountConf, setMenuCountConf] = useState({});
 

--- a/src/headerV2/src/index.tsx
+++ b/src/headerV2/src/index.tsx
@@ -123,12 +123,9 @@ const Header: FC<PropsWithChildren<UserStoreStateProps>> = ({ user, toastContext
   });
 
   const [_, setCookie] = useCookies([customJwtCookieKey]);
-  const unansweredChatsLength = useStore((state) =>
-      state.unansweredChatsLength()
-  );
-  const forwardedChatsLength = useStore((state) =>
-      state.forwordedChatsLength()
-  );
+  const unansweredChatsLength = useStore((state) => state.unansweredChatsLength());
+  const forwardedChatsLength = useStore((state) => state.forwordedChatsLength());
+  const pendingChatsLength = useStore((state) => state.pendingChatsLength());
 
   const userProfileSettingsMutation = useMutation({
     mutationFn: async (data: UserProfileSettings) => {
@@ -293,20 +290,22 @@ const Header: FC<PropsWithChildren<UserStoreStateProps>> = ({ user, toastContext
                           textTransform: "lowercase",
                         }}
                     >
-                      <strong>{unansweredChatsLength}</strong>{" "}
-                      {t("chat.unanswered")} <strong>{forwardedChatsLength}</strong>{" "}
-                      {t("chat.forwarded")}
+                      <strong>{unansweredChatsLength}</strong> {t("chat.unanswered")} {" "}
+                      <strong>{forwardedChatsLength}</strong> {t("chat.forwarded")} {" "}
+                      <strong>{pendingChatsLength}</strong> {t("chat.pending")} {" "}
                     </p>
-                    <Switch
-                        onCheckedChange={handleCsaStatusChange}
-                        checked={chatCsaActive}
-                        label={t("global.csaStatus")}
-                        hideLabel
-                        name="csaStatus"
-                        onColor="#308653"
-                        onLabel={t("global.present") || ""}
-                        offLabel={t("global.away") || ""}
-                    />
+                    <div>
+                      <Switch
+                          onCheckedChange={handleCsaStatusChange}
+                          checked={chatCsaActive}
+                          label={t("global.csaStatus")}
+                          hideLabel
+                          name="csaStatus"
+                          onColor="#308653"
+                          onLabel={t("global.present") || ""}
+                          offLabel={t("global.away") || ""}
+                      />
+                    </div>
                   </Track>
                   <span
                       style={{

--- a/src/headerV2/src/store/store.ts
+++ b/src/headerV2/src/store/store.ts
@@ -27,6 +27,7 @@ interface StoreState {
   unansweredChatsLength: () => number;
   messagesMap: () => Map<string, number>;
   forwordedChatsLength: () => number;
+  pendingChatsLength: () => number;
   loadActiveChats: () => Promise<void>;
   getGroupedActiveChats: () => GroupedChat;
   getGroupedUnansweredChats: () => GroupedChat;
@@ -86,6 +87,7 @@ const useStore = create<StoreState>((set, get, _) => ({
   },
   unansweredChatsLength: () => get().unansweredChats().length,
   forwordedChatsLength: () => get().forwordedChats().length,
+  pendingChatsLength: () => get().pendingChats.length,
   messagesMap: () => {
     const map = new Map<string, number>();
 


### PR DESCRIPTION
- Move hook from module to header library for reusability.
- Add pending chat count to header.