### PR TITLE
1325 popup duration

### DIFF
--- a/src/headerV2/CHANGELOG.md
+++ b/src/headerV2/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All changes to this project will be documented in this file.
 
+## [0.1.35] - 07-05-2025
+
+- Updated default toast duration to be 5 seconds.
+
 ## [0.1.34] - 30-04-2025
 
 - Improved adding comment to away status UI

--- a/src/headerV2/package.json
+++ b/src/headerV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buerokratt-ria/header",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Generic Header component that would be injected as dependency.",
   "main": "index.ts",
   "scripts": {},

--- a/src/headerV2/src/constants/config.ts
+++ b/src/headerV2/src/constants/config.ts
@@ -3,7 +3,7 @@ export const WELCOME_MESSAGE_LENGTH = 250;
 export const STATUS_COMMENT_LENGTH = 100;
 export const USER_IDLE_STATUS_TIMEOUT = 900000; // milliseconds - 15 minutes
 export const CHAT_INPUT_LENGTH = 500;
-export const TOAST_TIMEOUT = 2000;
+export const TOAST_TIMEOUT = 5000;
 export const CHAT_HISTORY_PREFERENCES_KEY = 'chat-history-preferences';
 
 export const isHiddenFeaturesEnabled = 


### PR DESCRIPTION
- Set default popup duration to 5 seconds

Related [task](https://github.com/buerokratt/Buerokratt-Chatbot/issues/1325).